### PR TITLE
Fix time window parsing in route service

### DIFF
--- a/app/orm-service/src/services/route_service.py
+++ b/app/orm-service/src/services/route_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
+from datetime import time as dt_time
 from typing import Sequence
 from uuid import UUID
 
@@ -26,8 +27,12 @@ async def save_routes(
     for plan in plans:
         courier_id = UUID(str(plan["courier_id"]))
         tw_start_str, tw_end_str = plan.get("time_window", [None, None])  # type: ignore
-        tw_start = datetime.fromisoformat(tw_start_str).time() if tw_start_str else now.time()  # type: ignore
-        tw_end = datetime.fromisoformat(tw_end_str).time() if tw_end_str else now.time()  # type: ignore
+        tw_start = (
+            dt_time.fromisoformat(tw_start_str) if tw_start_str else now.time()  # type: ignore
+        )
+        tw_end = (
+            dt_time.fromisoformat(tw_end_str) if tw_end_str else now.time()  # type: ignore
+        )
 
         route = Route(
             courier_id=courier_id,


### PR DESCRIPTION
## Summary
- parse time window values using `time.fromisoformat`
- keep existing date combination logic

## Testing
- `ruff format --check app/orm-service/src/services/route_service.py`
- `ruff check app/orm-service/src/services/route_service.py`
- (attempted) `curl` to OSRM service

------
https://chatgpt.com/codex/tasks/task_e_685000ec32dc832ebb49c6fc113f94f5