### PR TITLE
Remove deprecated ingest_addresses helper

### DIFF
--- a/app/osrm-service/src/services/logistics_service.py
+++ b/app/osrm-service/src/services/logistics_service.py
@@ -22,13 +22,6 @@ def _distinct_addresses(payload: Logistics) -> Generator[AddressRead, Any, None]
                 yield addr
 
 
-async def ingest_addresses(payload: Logistics) -> None:
-    addresses: List[AddressRead] = [payload.warehouse]
-    addresses.extend(list(_distinct_addresses(payload)))
-    async with get_neo4j_session() as session:
-        await upsert_addresses(session, addresses)
-
-
 async def _ensure_distances(
     addresses: List[AddressRead],
     addr_ids: List[str],


### PR DESCRIPTION
## Summary
- delete `ingest_addresses` helper in logistics service

## Testing
- `nox -s ruff_format`
- `nox -s ruff`
- `nox -s mypy` *(fails: "Error importing plugin 'sqlalchemy.ext.mypy.plugin'")*
- `nox -s tests` *(fails: `ERROR: file or directory not found: tests/`)*

------
https://chatgpt.com/codex/tasks/task_e_685000ee1fe8832ebbbf815b5d03c1cc