### PR TITLE
Improve OSRM connection error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# DeliveryDrive
+
+This repository contains multiple FastAPI services that communicate with each other via HTTP.
+
+## Running the services
+
+The easiest way to start all dependencies is via `docker-compose`:
+
+```bash
+docker-compose up
+```
+
+The `orm-service` communicates with the `osrm-service` using the URL specified by the `OSRM_SERVICE_URL` environment variable. When running via `docker-compose` this is set automatically. If you run the services separately, make sure `OSRM_SERVICE_URL` points to the reachable `osrm-service` instance (by default it is exposed on port `6060`).

--- a/app/orm-service/src/api/logistics.py
+++ b/app/orm-service/src/api/logistics.py
@@ -31,7 +31,8 @@ async def get_logistics(
                 json=logistics.model_dump(mode="json"),
             )
     except httpx.RequestError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        detail = f"Failed to reach OSRM service at {OSRM_URL}: {exc}"
+        raise HTTPException(status_code=502, detail=detail) from exc
 
     # The OSRM service now returns 200 on success
     if resp.status_code != status.HTTP_200_OK:
@@ -53,7 +54,8 @@ async def assign_routes(
                 json=logistics.model_dump(mode="json"),
             )
     except httpx.RequestError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        detail = f"Failed to reach OSRM service at {OSRM_URL}: {exc}"
+        raise HTTPException(status_code=502, detail=detail) from exc
 
     if resp.status_code != status.HTTP_200_OK:
         raise HTTPException(status_code=resp.status_code, detail=resp.text)


### PR DESCRIPTION
## Summary
- improve error messages when OSRM service is unreachable
- add project README with docker-compose hint

## Testing
- `ruff format app/orm-service/src/api/logistics.py --diff`
- `ruff check app/orm-service/src/api/logistics.py`


------
https://chatgpt.com/codex/tasks/task_e_685006984eac832eaa8eec2a12cc9301