### PR TITLE
Improve OSRM connection error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# DeliveryDrive
+
+This repository contains multiple FastAPI services that communicate with each other via HTTP.
+
+## Running the services
+
+The easiest way to start all dependencies is via `docker-compose`:
+
+```bash
+docker-compose up
+```
+
+The `orm-service` communicates with the `osrm-service` using the URL specified by the `OSRM_SERVICE_URL` environment variable. When running via `docker-compose` this is set automatically. If you run the services separately, make sure `OSRM_SERVICE_URL` points to the reachable `osrm-service` instance (by default it is exposed on port `6060`).
+
+At least one `Transport` record must exist in the database for route assignment to work. You can create a transport via the API or directly in the database before hitting the `/logistics/assign` endpoint.

--- a/app/orm-service/src/api/logistics.py
+++ b/app/orm-service/src/api/logistics.py
@@ -24,6 +24,8 @@ async def get_logistics(
     session: AsyncSession = Depends(get_session_with_user),
 ) -> dict[str, Any]:
     logistics: Logistics = await build_logistics(session, order_ids)
+    if not logistics.creates:
+        raise HTTPException(status_code=409, detail="No transports available")
     try:
         async with httpx.AsyncClient(base_url=OSRM_URL, timeout=5.0) as client:
             resp: httpx.Response = await client.post(
@@ -31,7 +33,8 @@ async def get_logistics(
                 json=logistics.model_dump(mode="json"),
             )
     except httpx.RequestError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        detail = f"Failed to reach OSRM service at {OSRM_URL}: {exc}"
+        raise HTTPException(status_code=502, detail=detail) from exc
 
     # The OSRM service now returns 200 on success
     if resp.status_code != status.HTTP_200_OK:
@@ -46,6 +49,8 @@ async def assign_routes(
     session: AsyncSession = Depends(get_session_with_user),
 ) -> dict[str, list[str]]:
     logistics: Logistics = await build_logistics(session, order_ids)
+    if not logistics.creates:
+        raise HTTPException(status_code=409, detail="No transports available")
     try:
         async with httpx.AsyncClient(base_url=OSRM_URL, timeout=5.0) as client:
             resp: httpx.Response = await client.post(
@@ -53,7 +58,8 @@ async def assign_routes(
                 json=logistics.model_dump(mode="json"),
             )
     except httpx.RequestError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        detail = f"Failed to reach OSRM service at {OSRM_URL}: {exc}"
+        raise HTTPException(status_code=502, detail=detail) from exc
 
     if resp.status_code != status.HTTP_200_OK:
         raise HTTPException(status_code=resp.status_code, detail=resp.text)


### PR DESCRIPTION
## Summary
- improve error messages when OSRM service is unreachable
- add project README with docker-compose hint
- detect missing transports before calling OSRM service

## Testing
- `ruff format app/orm-service/src/api/logistics.py --diff`
- `ruff check app/orm-service/src/api/logistics.py`


------
https://chatgpt.com/codex/tasks/task_e_685006984eac832eaa8eec2a12cc9301