### PR TITLE
Shift route saving to osrm-service

### DIFF
--- a/app/orm-service/src/api/logistics.py
+++ b/app/orm-service/src/api/logistics.py
@@ -10,7 +10,6 @@ from src.core.config import Settings, get_settings
 from src.dependencies.db import get_session_with_user
 from src.schemas.logistics import Logistics
 from src.services.logistics_service import build_logistics
-from src.services.route_service import save_routes
 
 router = APIRouter(prefix="/logistics", tags=["Logistics"])
 
@@ -41,27 +40,3 @@ async def get_logistics(
     return cast(dict[str, Any], resp.json())
 
 
-@router.post("/assign", status_code=status.HTTP_201_CREATED)
-async def assign_routes(
-    order_ids: list[UUID],
-    session: AsyncSession = Depends(get_session_with_user),
-) -> dict[str, list[str]]:
-    logistics: Logistics = await build_logistics(session, order_ids)
-    try:
-        async with httpx.AsyncClient(base_url=OSRM_URL, timeout=5.0) as client:
-            resp: httpx.Response = await client.post(
-                "/logistics/",
-                json=logistics.model_dump(mode="json"),
-            )
-    except httpx.RequestError as exc:
-        detail = f"Failed to reach OSRM service at {OSRM_URL}: {exc}"
-        raise HTTPException(status_code=502, detail=detail) from exc
-
-    if resp.status_code != status.HTTP_200_OK:
-        raise HTTPException(status_code=resp.status_code, detail=resp.text)
-
-    data = cast(dict[str, Any], resp.json())
-    routes_data = cast(list[dict[str, Any]], data.get("routes", []))
-    created = await save_routes(session, routes_data)
-    await session.commit()
-    return {"routes": [str(r.id) for r in created]}

--- a/app/osrm-service/src/api/logistics.py
+++ b/app/osrm-service/src/api/logistics.py
@@ -1,14 +1,19 @@
 # src/api/logistics.py
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
 from neo4j._async.work.session import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession as DBSession
 
 from src.core.config import Settings, get_settings
 from src.db.graph import get_neo4j_session
+from src.db.session import get_session
 from src.schemas.logistics import Logistics
+from src.services.logistics_builder import build_logistics
 from src.services.logistics_service import process_logistics
+from src.services.route_service import save_routes
 
 router = APIRouter(prefix="/logistics", tags=["Logistics"])
 
@@ -27,3 +32,16 @@ async def upload_logistics(
     settings: Settings = get_settings()
     routes: list[dict[str, Any]] = await process_logistics(payload, settings)
     return {"routes": routes}
+
+
+@router.post("/assign", status_code=status.HTTP_201_CREATED)
+async def assign_routes(
+    order_ids: list[UUID],
+    session: DBSession = Depends(get_session),
+) -> dict[str, list[str]]:
+    payload: Logistics = await build_logistics(session, order_ids)
+    settings: Settings = get_settings()
+    plans: list[dict[str, Any]] = await process_logistics(payload, settings)
+    created = await save_routes(session, plans)
+    await session.commit()
+    return {"routes": [str(r.id) for r in created]}

--- a/app/osrm-service/src/services/logistics_builder.py
+++ b/app/osrm-service/src/services/logistics_builder.py
@@ -1,0 +1,126 @@
+from datetime import time as dt_time
+from typing import Literal, Sequence, Tuple
+from uuid import UUID
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
+
+from src.db.models import (
+    Address,
+    Client,
+    CourierSchedule,
+    Order,
+    OrderItem,
+    Transport,
+    User,
+    Warehouse,
+)
+from src.schemas.logistics import (
+    AddressRead,
+    Create,
+    Logistics,
+)
+from src.schemas.logistics import (
+    Order as OrderSchema,
+)
+from src.schemas.logistics import (
+    TransportType as TransportTypeSchema,
+)
+
+DEFAULT_SERVICE_DURATION_SEC = 1_500  # ~25 minutes
+DEFAULT_COURIER_START: dt_time = dt_time(9)
+DEFAULT_COURIER_END: dt_time = dt_time(18)
+
+
+async def build_logistics(
+    session: AsyncSession,
+    order_ids: Sequence[UUID],
+) -> Logistics:
+    stmt_orders: Select[Tuple[Order]] = (
+        select(Order)
+        .where(Order.id.in_(order_ids))
+        .options(
+            joinedload(Order.client).joinedload(Client.address),
+            selectinload(Order.items).joinedload(OrderItem.heater_type),
+        )
+    )
+    orders_db: Sequence[Order] = (await session.scalars(stmt_orders)).all()
+    if len(orders_db) != len(order_ids):
+        missing: set[UUID] = set(order_ids) - {o.id for o in orders_db}
+        raise ValueError(f"Orders not found: {', '.join(map(str, missing))}")
+
+    orders: list[OrderSchema] = []
+    for order in orders_db:
+        addr: Address | None = order.client.address  # type: ignore
+        if addr is None:
+            raise ValueError(f"Order {order.id} has no address")
+
+        weight: float | Literal[0] = sum(
+            item.quantity * item.heater_type.weight for item in order.items
+        )
+        orders.append(
+            OrderSchema(
+                order_id=order.id,
+                address=AddressRead(
+                    id=addr.id,
+                    city=addr.city,
+                    street=addr.street,
+                    building=addr.building,
+                    lat=addr.lat,
+                    lon=addr.lon,
+                ),
+                weight=weight,
+                service_duration=DEFAULT_SERVICE_DURATION_SEC,
+                time_window=[order.window_start, order.window_end],
+            )
+        )
+
+    warehouse_db: Warehouse | None = await session.scalar(
+        select(Warehouse).options(joinedload(Warehouse.address)).limit(1)
+    )
+    if warehouse_db is None:
+        raise ValueError("Warehouse not found")
+
+    warehouse = AddressRead(
+        id=warehouse_db.address.id,
+        city=warehouse_db.address.city,
+        street=warehouse_db.address.street,
+        building=warehouse_db.address.building,
+        lat=warehouse_db.address.lat,
+        lon=warehouse_db.address.lon,
+    )
+
+    stmt_transports: Select[Tuple[Transport]] = (
+        select(Transport)
+        .options(
+            joinedload(Transport.transport_type),
+            selectinload(Transport.courier).joinedload(User.schedules),
+        )
+        .order_by(Transport.id)
+    )
+    transports_db: Sequence[Transport] = (await session.scalars(stmt_transports)).all()
+
+    creates: list[Create] = []
+    for t in transports_db:
+        schedule: CourierSchedule | None = next(iter(t.courier.schedules), None)
+        creates.append(
+            Create(
+                courier_id=t.courier_id,
+                time_window=[
+                    schedule.start_time if schedule else DEFAULT_COURIER_START,
+                    schedule.end_time if schedule else DEFAULT_COURIER_END,
+                ],
+                transport_type=TransportTypeSchema(
+                    name=t.transport_type.name,
+                    avg_speed=t.transport_type.avg_speed,
+                    capacity=t.transport_type.capacity,
+                ),
+            )
+        )
+
+    return Logistics(
+        warehouse=warehouse,
+        orders=orders,
+        creates=creates,
+    )

--- a/app/osrm-service/src/services/route_service.py
+++ b/app/osrm-service/src/services/route_service.py
@@ -7,11 +7,19 @@ from datetime import time as dt_time
 from typing import Sequence
 from uuid import UUID
 
-from sqlalchemy import update
+from sqlalchemy import Select, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.db.models import Order, Route, RouteItem, Tracking
-from src.repositories.tables.order_status import OrderStatusRepository
+from src.db.models import Order, OrderStatus, Route, RouteItem, Tracking
+
+
+async def _get_status_id(session: AsyncSession, code: str) -> int:
+    stmt: Select[tuple[int]] = select(OrderStatus.id).where(OrderStatus.code == code)
+    res = await session.execute(stmt)
+    status_id: int | None = res.scalars().first()
+    if status_id is None:
+        raise ValueError(f"Status with code '{code}' not found")
+    return status_id
 
 
 async def save_routes(
@@ -20,7 +28,7 @@ async def save_routes(
 ) -> list[Route]:
     """Persist routes and create tracking records."""
 
-    scheduled_id: int = await OrderStatusRepository().get_code_id(session, "scheduled")
+    scheduled_id: int = await _get_status_id(session, "scheduled")
     created: list[Route] = []
     now: datetime = datetime.now(timezone.utc)
 
@@ -58,7 +66,9 @@ async def save_routes(
             )
 
         if order_ids:
-            await session.execute(update(Order).where(Order.id.in_(order_ids)).values(status_id=scheduled_id))
+            await session.execute(
+                update(Order).where(Order.id.in_(order_ids)).values(status_id=scheduled_id)
+            )
 
         created.append(route)
 


### PR DESCRIPTION
## Summary
- move route assignment endpoint from ORM service to OSRM service
- implement `logistics_builder` and updated route persistence service
- clean up ORM service API

## Testing
- `ruff check src` in `app/osrm-service`
- `ruff check src` in `app/orm-service`
- `mypy src --exclude=tests/ --explicit-package-bases` *(fails: `src/utils/http_error.py:5: error: Class cannot subclass "HTTPException" (has type "Any")` and others)*

------
https://chatgpt.com/codex/tasks/task_e_68500a93b278832ea4aef616e94456bd