### PR TITLE
Improve logging across services

### DIFF
--- a/app/orm-service/src/api/logistics.py
+++ b/app/orm-service/src/api/logistics.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
+from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.config import Settings, get_settings
@@ -22,6 +23,7 @@ async def get_logistics(
     order_ids: list[UUID],
     session: AsyncSession = Depends(get_session_with_user),
 ) -> dict[str, Any]:
+    logger.info("Building logistics for %d orders", len(order_ids))
     logistics: Logistics = await build_logistics(session, order_ids)
     try:
         async with httpx.AsyncClient(base_url=OSRM_URL, timeout=5.0) as client:
@@ -31,9 +33,16 @@ async def get_logistics(
             )
     except httpx.RequestError as exc:
         detail = f"Failed to reach OSRM service at {OSRM_URL}: {exc}"
+        logger.error(detail)
         raise HTTPException(status_code=502, detail=detail) from exc
 
     if resp.status_code != status.HTTP_200_OK:
+        logger.error(
+            "OSRM service returned %s: %s",
+            resp.status_code,
+            resp.text,
+        )
         raise HTTPException(status_code=resp.status_code, detail=resp.text)
 
+    logger.info("Received routes from OSRM service")
     return cast(dict[str, Any], resp.json())

--- a/app/orm-service/src/services/logistics_service.py
+++ b/app/orm-service/src/services/logistics_service.py
@@ -3,6 +3,7 @@ from datetime import time as dt_time
 from typing import Literal, Sequence, Tuple
 from uuid import UUID
 
+from loguru import logger
 from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
@@ -36,6 +37,7 @@ async def build_logistics(
     session: AsyncSession,
     order_ids: Sequence[UUID],
 ) -> Logistics:
+    logger.debug("Building logistics for %d orders", len(order_ids))
     stmt_orders: Select[Tuple[Order]] = (
         select(Order)
         .where(Order.id.in_(order_ids))
@@ -47,6 +49,7 @@ async def build_logistics(
     orders_db: Sequence[Order] = (await session.scalars(stmt_orders)).all()
     if len(orders_db) != len(order_ids):
         missing: set[UUID] = set(order_ids) - {o.id for o in orders_db}
+        logger.error("Orders not found: %s", ", ".join(map(str, missing)))
         raise ValueError(f"Orders not found: {', '.join(map(str, missing))}")
 
     orders: list[OrderSchema] = []
@@ -78,6 +81,7 @@ async def build_logistics(
         select(Warehouse).options(joinedload(Warehouse.address)).limit(1)
     )
     if warehouse_db is None:
+        logger.error("Warehouse not found")
         raise ValueError("Warehouse not found")
 
     warehouse = AddressRead(
@@ -98,6 +102,7 @@ async def build_logistics(
         .order_by(Transport.id)
     )
     transports_db: Sequence[Transport] = (await session.scalars(stmt_transports)).all()
+    logger.debug("Fetched %d transports", len(transports_db))
 
     creates: list[CreateSchema] = []
     for t in transports_db:
@@ -118,8 +123,11 @@ async def build_logistics(
             )
         )
 
-    return Logistics(
+    logistics = Logistics(
         warehouse=warehouse,
         orders=orders,
         creates=creates,
     )
+
+    logger.debug("Built logistics: %d orders, %d couriers", len(orders), len(creates))
+    return logistics

--- a/app/osrm-service/src/api/logistics.py
+++ b/app/osrm-service/src/api/logistics.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncIterator
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
+from loguru import logger
 from neo4j._async.work.session import AsyncSession
 from sqlalchemy.ext.asyncio import AsyncSession as DBSession
 
@@ -29,8 +30,14 @@ async def upload_logistics(
     payload: Logistics,
     neo: AsyncSession = Depends(neo4j_session_ctx),
 ) -> dict[str, list[dict[str, Any]]]:
+    logger.info(
+        "Received logistics payload with %d orders and %d couriers",
+        len(payload.orders),
+        len(payload.creates),
+    )
     settings: Settings = get_settings()
     routes: list[dict[str, Any]] = await process_logistics(payload, settings)
+    logger.info("Generated %d routes", len(routes))
     return {"routes": routes}
 
 
@@ -39,9 +46,11 @@ async def assign_routes(
     order_ids: list[UUID],
     session: DBSession = Depends(get_session),
 ) -> dict[str, list[str]]:
+    logger.info("Assigning routes for %d orders", len(order_ids))
     payload: Logistics = await build_logistics(session, order_ids)
     settings: Settings = get_settings()
     plans: list[dict[str, Any]] = await process_logistics(payload, settings)
     created = await save_routes(session, plans)
     await session.commit()
+    logger.info("Saved %d routes", len(created))
     return {"routes": [str(r.id) for r in created]}

--- a/app/osrm-service/src/services/logistics_builder.py
+++ b/app/osrm-service/src/services/logistics_builder.py
@@ -56,9 +56,7 @@ async def build_logistics(
         if addr is None:
             raise ValueError(f"Order {order.id} has no address")
 
-        weight: float | Literal[0] = sum(
-            item.quantity * item.heater_type.weight for item in order.items
-        )
+        weight: float | Literal[0] = sum(item.quantity * item.heater_type.weight for item in order.items)
         orders.append(
             OrderSchema(
                 order_id=order.id,

--- a/app/osrm-service/src/services/logistics_service.py
+++ b/app/osrm-service/src/services/logistics_service.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Generator, List, Tuple
 
+from loguru import logger
+
 from src.core.config import Settings
 from src.db.graph import get_neo4j_session
 from src.repositories.neo4j.address import (
@@ -28,8 +30,10 @@ async def _ensure_distances(
     profile: str,
     settings: Settings,
 ) -> Dict[Tuple[str, str], float]:
+    logger.debug("Ensuring distances for %d addresses", len(addr_ids))
     async with get_neo4j_session() as session:
         existing = await fetch_distances(session, addr_ids)
+        logger.debug("Found %d distances in cache", len(existing))
 
         if len(existing) < len(addr_ids) * len(addr_ids):
             matrix = await fetch_distance_matrix(addresses, profile, settings)
@@ -46,6 +50,7 @@ async def _ensure_distances(
                         existing[key] = dist
 
             await upsert_distances(session, missing_rows)
+            logger.debug("Inserted %d missing distances", len(missing_rows))
 
         return existing
 
@@ -55,6 +60,7 @@ def _build_matrix(
     existing: Dict[Tuple[str, str], float],
 ) -> List[List[float]]:
     size: int = len(addr_ids)
+    logger.debug("Building distance matrix %dx%d", size, size)
     matrix: List[List[float]] = [[0.0 for _ in range(size)] for _ in range(size)]
 
     for i, from_id in enumerate(addr_ids):
@@ -68,11 +74,17 @@ def _build_matrix(
 
 
 async def process_logistics(payload: Logistics, settings: Settings) -> List[dict[str, Any]]:
+    logger.info(
+        "Processing logistics: %d orders, %d couriers",
+        len(payload.orders),
+        len(payload.creates),
+    )
     addresses: List[AddressRead] = [payload.warehouse]
     addresses.extend(list(_distinct_addresses(payload)))
 
     async with get_neo4j_session() as session:
         await upsert_addresses(session, addresses)
+        logger.debug("Upserted %d addresses", len(addresses))
 
     addr_ids: List[str] = [str(a.id) for a in addresses]
 
@@ -84,6 +96,7 @@ async def process_logistics(payload: Logistics, settings: Settings) -> List[dict
     )
 
     matrix: List[List[float]] = _build_matrix(addr_ids, existing)
+    logger.debug("Distance matrix built")
 
     routes = solve_vrp(
         matrix,
@@ -91,6 +104,7 @@ async def process_logistics(payload: Logistics, settings: Settings) -> List[dict
         payload.creates,
         payload.solver,
     )
+    logger.info("Route solver produced %d routes", len(routes))
 
     result: List[dict[str, Any]] = []
     for idx, route in enumerate(routes):

--- a/app/osrm-service/src/services/osrm_client.py
+++ b/app/osrm-service/src/services/osrm_client.py
@@ -1,6 +1,8 @@
+from time import perf_counter
 from typing import List, Sequence, cast
 
 import httpx
+from loguru import logger
 
 from src.core.config import Settings
 from src.schemas.logistics import AddressRead
@@ -11,8 +13,12 @@ async def fetch_distance_matrix(
 ) -> list[list[float]]:
     coords: str = ";".join(f"{a.lon},{a.lat}" for a in addresses)
     url: str = f"{settings.osrm_url.rstrip('/')}/table/v1/{profile}/{coords}"
+    logger.debug("Requesting OSRM matrix: %s", url)
+    start = perf_counter()
     async with httpx.AsyncClient(timeout=10.0) as client:
         resp: httpx.Response = await client.get(url, params={"annotations": "distance"})
-        resp.raise_for_status()
-        data = resp.json()
+    resp.raise_for_status()
+    duration = perf_counter() - start
+    logger.debug("OSRM response received in %.2f sec", duration)
+    data = resp.json()
     return cast(List[List[float]], data.get("distances", []))

--- a/app/osrm-service/src/services/route_service.py
+++ b/app/osrm-service/src/services/route_service.py
@@ -7,6 +7,7 @@ from datetime import time as dt_time
 from typing import Sequence
 from uuid import UUID
 
+from loguru import logger
 from sqlalchemy import Select, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,7 +28,7 @@ async def save_routes(
     plans: Sequence[dict[str, object]],
 ) -> list[Route]:
     """Persist routes and create tracking records."""
-
+    logger.info("Saving %d planned routes", len(plans))
     scheduled_id: int = await _get_status_id(session, "scheduled")
     created: list[Route] = []
     now: datetime = datetime.now(timezone.utc)
@@ -42,6 +43,12 @@ async def save_routes(
             dt_time.fromisoformat(tw_end_str) if tw_end_str else now.time()  # type: ignore
         )
 
+        order_ids: list[UUID] = [UUID(o) for o in plan.get("orders", [])]  # type: ignore
+        logger.debug(
+            "Creating route for courier %s with %d orders",
+            courier_id,
+            len(order_ids),
+        )
         route = Route(
             courier_id=courier_id,
             date=date.today(),
@@ -50,8 +57,6 @@ async def save_routes(
         )
         session.add(route)
         await session.flush()
-
-        order_ids: list[UUID] = [UUID(o) for o in plan.get("orders", [])]  # type: ignore
         for seq, oid in enumerate(order_ids):
             item = RouteItem(route_id=route.id, order_id=oid, sequence=seq)
             session.add(item)
@@ -66,10 +71,10 @@ async def save_routes(
             )
 
         if order_ids:
-            await session.execute(
-                update(Order).where(Order.id.in_(order_ids)).values(status_id=scheduled_id)
-            )
+            await session.execute(update(Order).where(Order.id.in_(order_ids)).values(status_id=scheduled_id))
 
         created.append(route)
+
+    logger.info("%d routes saved", len(created))
 
     return created

--- a/app/osrm-service/src/services/route_solver.py
+++ b/app/osrm-service/src/services/route_solver.py
@@ -1,6 +1,7 @@
 from datetime import time
 from uuid import UUID
 
+from loguru import logger
 from ortools.constraint_solver import pywrapcp, routing_enums_pb2
 
 from src.schemas.logistics import Create, Order, Solver
@@ -99,6 +100,7 @@ def solve_vrp(
     creates: list[Create],
     solver_cfg: Solver,
 ) -> list[list[UUID]]:
+    logger.debug("Solving VRP: %d orders, %d vehicles", len(orders), len(creates))
     num_nodes: int = len(distance_matrix)
     manager = pywrapcp.RoutingIndexManager(num_nodes, len(creates), 0)
     routing = pywrapcp.RoutingModel(manager)
@@ -121,6 +123,9 @@ def solve_vrp(
 
     solution = routing.SolveWithParameters(search_params)
     if solution is None:
+        logger.warning("VRP solver returned no solution")
         return []
 
-    return _extract_routes(routing, manager, solution, orders, creates)
+    routes = _extract_routes(routing, manager, solution, orders, creates)
+    logger.debug("VRP solver produced %d routes", len(routes))
+    return routes


### PR DESCRIPTION
## Summary
- add loguru logger to OSRM API endpoints for better tracing
- improve distance matrix and VRP solver logging
- log route persistence details
- add request logging around OSRM client
- extend ORM service with log messages when calling OSRM
- emit debug info in logistics builder

## Testing
- `nox -s ruff` within `app/osrm-service`
- `nox -s ruff_format` within `app/osrm-service`
- `nox -s ruff` within `app/orm-service`
- `nox -s ruff_format` within `app/orm-service`
- `nox -s mypy` *(fails: Error importing plugin "sqlalchemy.ext.mypy.plugin")*
- `nox -s tests` *(fails: file or directory not found: tests/)*


------
https://chatgpt.com/codex/tasks/task_e_6850156a42b0832eacbe991317135691