### PR TITLE
Fix OSRM service timeout

### DIFF
--- a/app/orm-service/src/api/logistics.py
+++ b/app/orm-service/src/api/logistics.py
@@ -26,7 +26,7 @@ async def get_logistics(
     logger.info("Building logistics for %d orders", len(order_ids))
     logistics: Logistics = await build_logistics(session, order_ids)
     try:
-        async with httpx.AsyncClient(base_url=OSRM_URL, timeout=5.0) as client:
+        async with httpx.AsyncClient(base_url=OSRM_URL, timeout=30.0) as client:
             resp: httpx.Response = await client.post(
                 "/logistics/",
                 json=logistics.model_dump(mode="json"),

--- a/app/osrm-service/src/services/osrm_client.py
+++ b/app/osrm-service/src/services/osrm_client.py
@@ -15,7 +15,7 @@ async def fetch_distance_matrix(
     url: str = f"{settings.osrm_url.rstrip('/')}/table/v1/{profile}/{coords}"
     logger.debug("Requesting OSRM matrix: %s", url)
     start = perf_counter()
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    async with httpx.AsyncClient(timeout=30.0) as client:
         resp: httpx.Response = await client.get(url, params={"annotations": "distance"})
     resp.raise_for_status()
     duration = perf_counter() - start


### PR DESCRIPTION
## Summary
- bump OSRM request timeouts so larger payloads don't fail

## Testing
- `ruff format src/api/logistics.py`
- `ruff check src/api/logistics.py`
- `ruff format src/services/osrm_client.py`
- `ruff check src/services/osrm_client.py`
- `mypy src/api/logistics.py` *(fails: Error importing plugin 'sqlalchemy.ext.mypy.plugin')*
- `mypy src/services/osrm_client.py` *(fails: Error importing plugin 'sqlalchemy.ext.mypy.plugin')*
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68501d00a46c832e9cd0241a283fea9e