### PR TITLE
Fix OSRM matrix caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ docker-compose up
 ```
 
 The `orm-service` communicates with the `osrm-service` using the URL specified by the `OSRM_SERVICE_URL` environment variable. When running via `docker-compose` this is set automatically. If you run the services separately, make sure `OSRM_SERVICE_URL` points to the reachable `osrm-service` instance (by default it is exposed on port `6060`).
+
+## Кэширование матрицы OSRM
+
+`osrm-service` сохраняет рассчитанные расстояния между всеми адресами партии в Neo4j.
+При первом обращении формируется полный запрос к `/table` OSRM с параметрами
+`sources=all&destinations=all&annotations=distance`. Если адресов больше ста,
+запрос разбивается на части и итоговая матрица собирается из частичных ответов.
+Результат кэшируется как ориентированный граф `(:Address)-[:DISTANCE]->(:Address)`;
+всего создаётся `N × (N-1)` рёбер. Повторные вызовы используют уже сохранённые
+значения.

--- a/app/osrm-service/src/services/logistics_service.py
+++ b/app/osrm-service/src/services/logistics_service.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Dict, Generator, List, Tuple, Sequence
 
 from loguru import logger
 
@@ -24,6 +24,17 @@ def _distinct_addresses(payload: Logistics) -> Generator[AddressRead, Any, None]
                 yield addr
 
 
+def _pairs(addr_ids: Sequence[str], matrix: list[list[float]]) -> list[tuple[str, str, float]]:
+    """Generate distance tuples from OSRM matrix."""
+    rows: list[tuple[str, str, float]] = []
+    for i, from_id in enumerate(addr_ids):
+        for j, to_id in enumerate(addr_ids):
+            if i == j:
+                continue
+            rows.append((from_id, to_id, float(matrix[i][j])))
+    return rows
+
+
 async def _ensure_distances(
     addresses: List[AddressRead],
     addr_ids: List[str],
@@ -35,22 +46,23 @@ async def _ensure_distances(
         existing = await fetch_distances(session, addr_ids)
         logger.debug("Found %d distances in cache", len(existing))
 
-        if len(existing) < len(addr_ids) * len(addr_ids):
+        expected = len(addr_ids) * (len(addr_ids) - 1)
+        if len(existing) < expected:
             matrix = await fetch_distance_matrix(addresses, profile, settings)
-            missing_rows = []
+            sample = [row[:3] for row in matrix[:3]]
+            logger.debug("Matrix sample %s", sample)
 
-            for i, from_id in enumerate(addr_ids):
-                for j, to_id in enumerate(addr_ids):
-                    if i == j:
-                        continue
-                    key = (from_id, to_id)
-                    dist = float(matrix[i][j]) if matrix else 0.0
-                    if key not in existing:
-                        missing_rows.append((from_id, to_id, dist))
-                        existing[key] = dist
+            all_pairs = _pairs(addr_ids, matrix)
+            missing_rows = [(f, t, d) for f, t, d in all_pairs if (f, t) not in existing]
 
             await upsert_distances(session, missing_rows)
             logger.debug("Inserted %d missing distances", len(missing_rows))
+
+            for f, t, d in missing_rows:
+                existing[(f, t)] = d
+
+        if len(existing) != expected:
+            raise ValueError("Distance matrix incomplete")
 
         return existing
 

--- a/app/osrm-service/src/services/osrm_client.py
+++ b/app/osrm-service/src/services/osrm_client.py
@@ -11,14 +11,49 @@ from src.schemas.logistics import AddressRead
 async def fetch_distance_matrix(
     addresses: Sequence[AddressRead], profile: str, settings: Settings
 ) -> list[list[float]]:
-    coords: str = ";".join(f"{a.lon},{a.lat}" for a in addresses)
-    url: str = f"{settings.osrm_url.rstrip('/')}/table/v1/{profile}/{coords}"
-    logger.debug("Requesting OSRM matrix: %s", url)
-    start = perf_counter()
+    """Fetch full distance matrix for the given addresses.
+
+    The OSRM table service has a hard limit on the number of coordinates per
+    request, therefore batches of more than 100 points are sliced and the
+    resulting matrices are merged together.
+    """
+
+    coords_all: list[str] = [f"{a.lon},{a.lat}" for a in addresses]
+    n: int = len(coords_all)
+    matrix: list[list[float]] = [[0.0 for _ in range(n)] for _ in range(n)]
+
+    chunk: int = 50
+    start_total = perf_counter()
     async with httpx.AsyncClient(timeout=300.0) as client:
-        resp: httpx.Response = await client.get(url, params={"annotations": "distance"})
-    resp.raise_for_status()
-    duration = perf_counter() - start
-    logger.debug("OSRM response received in %.2f sec", duration)
-    data = resp.json()
-    return cast(List[List[float]], data.get("distances", []))
+        for i in range(0, n, chunk):
+            for j in range(0, n, chunk):
+                src_idx = list(range(i, min(i + chunk, n)))
+                dst_idx = list(range(j, min(j + chunk, n)))
+
+                coord_subset = [coords_all[k] for k in src_idx + dst_idx]
+                coord_str = ";".join(coord_subset)
+                url = f"{settings.osrm_url.rstrip('/')}/table/v1/{profile}/{coord_str}"
+
+                params = {
+                    "sources": ";".join(str(k) for k in range(len(src_idx))),
+                    "destinations": ";".join(
+                        str(len(src_idx) + k) for k in range(len(dst_idx))
+                    ),
+                    "annotations": "distance",
+                }
+                logger.debug("Requesting OSRM matrix: %s", url)
+                start = perf_counter()
+                resp: httpx.Response = await client.get(url, params=params)
+                resp.raise_for_status()
+                duration = perf_counter() - start
+                logger.debug("OSRM response received in %.2f sec", duration)
+
+                data = resp.json()
+                distances = cast(List[List[float]], data.get("distances", []))
+                for ii, s in enumerate(src_idx):
+                    for jj, d in enumerate(dst_idx):
+                        matrix[s][d] = distances[ii][jj]
+
+    duration_total = perf_counter() - start_total
+    logger.debug("Total OSRM time %.2f sec for %d addresses", duration_total, n)
+    return matrix

--- a/app/osrm-service/tests/test_ensure_distances.py
+++ b/app/osrm-service/tests/test_ensure_distances.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from uuid import uuid4
+from typing import List
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+from src.schemas.logistics import AddressRead
+from src.services import logistics_service
+
+
+@pytest.mark.asyncio
+async def test_ensure_distances_inserts_all(monkeypatch):
+    addresses: List[AddressRead] = [
+        AddressRead(id=uuid4(), city="c", street="s", building="b", lat=i, lon=i)
+        for i in range(10)
+    ]
+    addr_ids = [str(a.id) for a in addresses]
+    fake_store: dict[tuple[str, str], float] = {}
+
+    async def fake_fetch_distances(session, ids):
+        return {k: v for k, v in fake_store.items() if k[0] in ids and k[1] in ids}
+
+    async def fake_upsert_distances(session, rows):
+        for f, t, d in rows:
+            fake_store[(f, t)] = d
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def fake_get_session():
+        yield None
+
+    async def fake_fetch_matrix(addresses, profile, settings):
+        n = len(addresses)
+        return [[float(i * n + j) for j in range(n)] for i in range(n)]
+
+    monkeypatch.setattr(logistics_service, "fetch_distances", fake_fetch_distances)
+    monkeypatch.setattr(logistics_service, "upsert_distances", fake_upsert_distances)
+    monkeypatch.setattr(logistics_service, "get_neo4j_session", fake_get_session)
+    monkeypatch.setattr(logistics_service, "fetch_distance_matrix", fake_fetch_matrix)
+
+    settings = logistics_service.Settings()
+    result = await logistics_service._ensure_distances(addresses, addr_ids, "driving", settings)
+    assert len(fake_store) == 90
+    assert len(result) == 90

--- a/app/osrm-service/tests/test_pairs.py
+++ b/app/osrm-service/tests/test_pairs.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from uuid import uuid4
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from src.services.logistics_service import _pairs
+
+
+def test_pairs_complete():
+    ids = [str(uuid4()) for _ in range(3)]
+    matrix = [
+        [0.0, 1.0, 2.0],
+        [3.0, 0.0, 4.0],
+        [5.0, 6.0, 0.0],
+    ]
+    result = _pairs(ids, matrix)
+    assert len(result) == 6
+    expected = {
+        (ids[0], ids[1], 1.0),
+        (ids[0], ids[2], 2.0),
+        (ids[1], ids[0], 3.0),
+        (ids[1], ids[2], 4.0),
+        (ids[2], ids[0], 5.0),
+        (ids[2], ids[1], 6.0),
+    }
+    assert set(result) == expected


### PR DESCRIPTION
## Summary
- request complete oriented OSRM matrix and merge partial batches
- validate distances before VRP run
- expose helper to convert matrix into (from, to) pairs
- add tests for OSRM matrix pairs and caching
- document OSRM matrix caching behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685020f36a8c832eaa65aa13ed106448