### PR TITLE
Implement async route saving

### DIFF
--- a/app/osrm-service/src/api/logistics.py
+++ b/app/osrm-service/src/api/logistics.py
@@ -2,6 +2,7 @@
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 from uuid import UUID
+import asyncio
 
 from fastapi import APIRouter, Depends, status
 from loguru import logger
@@ -11,13 +12,19 @@ from sqlalchemy.ext.asyncio import AsyncSession as DBSession
 from src.core.config import Settings, get_settings
 from src.db.graph import get_neo4j_session
 from src.db.models import Route
-from src.db.session import get_session
+from src.db.session import get_session, AsyncSessionFactory
 from src.schemas.logistics import Logistics
 from src.services.logistics_builder import build_logistics
 from src.services.logistics_service import process_logistics
 from src.services.route_service import save_routes
 
 router = APIRouter(prefix="/logistics", tags=["Logistics"])
+
+
+async def _save_routes_bg(plans: list[dict[str, Any]]) -> None:
+    async with AsyncSessionFactory() as session:
+        async with session.begin():
+            await save_routes(session, plans)
 
 
 @asynccontextmanager
@@ -33,7 +40,8 @@ async def upload_logistics(
     logger.info(f"Received logistics payload with {len(payload.orders)} orders and {len(payload.creates)} couriers")
     settings: Settings = get_settings()
     routes: list[dict[str, Any]] = await process_logistics(payload, settings)
-    logger.info(f"Generated {len(routes)} routes")
+    asyncio.create_task(_save_routes_bg(routes))
+    logger.info(f"Generated {len(routes)} routes and scheduled save")
     return {"routes": routes}
 
 


### PR DESCRIPTION
## Summary
- save planned routes in the `upload_logistics` endpoint
- add asynchronous helper for saving routes in the background

## Testing
- `ruff check app/osrm-service/src/api/logistics.py`
- `ruff format app/osrm-service/src/api/logistics.py`
- `mypy app/osrm-service/src/api/logistics.py` *(fails: Cannot find implementations for dependencies)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685031eaf28c832e8395e34cf16f1e46