### PR TITLE
Async routes

### DIFF
--- a/app/osrm-service/src/api/logistics.py
+++ b/app/osrm-service/src/api/logistics.py
@@ -4,15 +4,13 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, status
 from loguru import logger
 from neo4j._async.work.session import AsyncSession
-from sqlalchemy.ext.asyncio import AsyncSession as DBSession
 
 from src.core.config import Settings, get_settings
 from src.db.graph import get_neo4j_session
-from src.db.models import Route
-from src.db.session import AsyncSessionFactory, get_session
+from src.db.session import AsyncSessionFactory
 from src.schemas.logistics import Logistics
 from src.services.logistics_builder import build_logistics
 from src.services.logistics_service import process_logistics
@@ -27,34 +25,44 @@ async def _save_routes_bg(plans: list[dict[str, Any]]) -> None:
             await save_routes(session, plans)
 
 
+async def _process_and_save(payload: Logistics, settings: Settings) -> None:
+    routes: list[dict[str, Any]] = await process_logistics(payload, settings)
+    await _save_routes_bg(routes)
+
+
+async def _assign_routes_bg(order_ids: list[UUID], settings: Settings) -> None:
+    async with AsyncSessionFactory() as session:
+        async with session.begin():
+            payload: Logistics = await build_logistics(session, order_ids)
+            plans: list[dict[str, Any]] = await process_logistics(payload, settings)
+            await save_routes(session, plans)
+
+
 @asynccontextmanager
 async def neo4j_session_ctx() -> AsyncIterator[AsyncSession]:
     async with get_neo4j_session() as session:
         yield session
 
 
-@router.post("/", status_code=status.HTTP_200_OK)
+@router.post("/", status_code=status.HTTP_202_ACCEPTED)
 async def upload_logistics(
     payload: Logistics,
-) -> dict[str, list[dict[str, Any]]]:
-    logger.info(f"Received logistics payload with {len(payload.orders)} orders and {len(payload.creates)} couriers")
+) -> dict[str, str]:
+    logger.info(
+        f"Received logistics payload with {len(payload.orders)} orders and {len(payload.creates)} couriers",
+    )
     settings: Settings = get_settings()
-    routes: list[dict[str, Any]] = await process_logistics(payload, settings)
-    asyncio.create_task(_save_routes_bg(routes))
-    logger.info(f"Generated {len(routes)} routes and scheduled save")
-    return {"routes": routes}
+    asyncio.create_task(_process_and_save(payload, settings))
+    logger.info("Scheduled logistics processing")
+    return {"status": "processing"}
 
 
-@router.post("/assign", status_code=status.HTTP_201_CREATED)
+@router.post("/assign", status_code=status.HTTP_202_ACCEPTED)
 async def assign_routes(
     order_ids: list[UUID],
-    session: DBSession = Depends(get_session),
-) -> dict[str, list[str]]:
+) -> dict[str, str]:
     logger.info(f"Assigning routes for {len(order_ids)} orders")
-    payload: Logistics = await build_logistics(session, order_ids)
     settings: Settings = get_settings()
-    plans: list[dict[str, Any]] = await process_logistics(payload, settings)
-    created: list[Route] = await save_routes(session, plans)
-    await session.commit()
-    logger.info(f"Saved {len(created)} routes")
-    return {"routes": [str(r.id) for r in created]}
+    asyncio.create_task(_assign_routes_bg(order_ids, settings))
+    logger.info("Scheduled route assignment")
+    return {"status": "processing"}


### PR DESCRIPTION
## Summary
- make `osrm-service` logistics endpoints run in the background

## Testing
- `nox -s ruff_format`
- `nox -s ruff`
- `nox -s mypy` *(fails: untyped code errors)*

------
https://chatgpt.com/codex/tasks/task_e_685034372004832ea5af9cdfdd04a80d