### PR TITLE
Fix ORTools worker configuration

### DIFF
--- a/app/osrm-service/src/services/route_solver.py
+++ b/app/osrm-service/src/services/route_solver.py
@@ -166,6 +166,13 @@ def solve_vrp(
         search_params.number_of_search_workers = solver_cfg.num_search_workers
     elif hasattr(search_params, "num_search_workers"):
         search_params.num_search_workers = solver_cfg.num_search_workers
+    else:
+        try:
+            search_params.sat_parameters.num_search_workers = solver_cfg.num_search_workers
+        except Exception:
+            logger.warning(
+                "ORTools: num_search_workers not supported — fallback to single thread"
+            )
     search_params.first_solution_strategy = routing_enums_pb2.FirstSolutionStrategy.PATH_CHEAPEST_ARC
     logger.debug(
         f"Search parameters: time_limit={solver_cfg.max_runtime_sec}, "


### PR DESCRIPTION
## Summary
- configure RoutingSearchParameters to use `sat_parameters.num_search_workers`

## Testing
- `ruff check .` *(fails: unused imports, unsorted imports)*

------
https://chatgpt.com/codex/tasks/task_e_68503ffdf7d4832eaa86fa3220976724