### PR TITLE
Add notifications when routes created

### DIFF
--- a/app/osrm-service/src/api/notifications.py
+++ b/app/osrm-service/src/api/notifications.py
@@ -1,0 +1,15 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.db.models import Notification
+from src.db.session import get_session
+
+router = APIRouter(prefix="/notifications", tags=["Notifications"])
+
+
+@router.patch("/{notification_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def mark_as_read(notification_id: UUID, session: AsyncSession = Depends(get_session)) -> None:
+    await session.execute(update(Notification).where(Notification.id == notification_id).values(is_read=True))

--- a/app/osrm-service/src/main.py
+++ b/app/osrm-service/src/main.py
@@ -3,7 +3,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from src.api import logistics
+from src.api import logistics, notifications
 
 app = FastAPI(title="osrm-servic")
 
@@ -27,3 +27,4 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 
 app.include_router(logistics.router)
+app.include_router(notifications.router)

--- a/app/osrm-service/src/services/route_service.py
+++ b/app/osrm-service/src/services/route_service.py
@@ -8,7 +8,16 @@ from loguru import logger
 from sqlalchemy import Result, Select, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.db.models import Order, OrderStatus, Route, RouteItem, Tracking
+from src.db.models import (
+    Notification,
+    Order,
+    OrderStatus,
+    Role,
+    Route,
+    RouteItem,
+    Tracking,
+    User,
+)
 
 
 async def _get_status_id(session: AsyncSession, code: str) -> int:
@@ -20,6 +29,17 @@ async def _get_status_id(session: AsyncSession, code: str) -> int:
     return status_id
 
 
+async def _get_manager_ids(session: AsyncSession) -> list[UUID]:
+    stmt: Select[tuple[UUID]] = select(User.id).join(Role, User.role_id == Role.id).where(Role.name == "manager")
+    res: Result[tuple[UUID]] = await session.execute(stmt)
+    return list(res.scalars())
+
+
+async def _create_notifications(session: AsyncSession, user_ids: Sequence[UUID], text: str) -> None:
+    session.add_all([Notification(user_id=uid, text=text) for uid in user_ids])
+    await session.flush()
+
+
 async def save_routes(
     session: AsyncSession,
     plans: Sequence[dict[str, object]],
@@ -28,6 +48,7 @@ async def save_routes(
     scheduled_id: int = await _get_status_id(session, "scheduled")
     created: list[Route] = []
     now: datetime = datetime.now(timezone.utc)
+    manager_ids: list[UUID] = await _get_manager_ids(session)
 
     for plan in plans:
         courier_id = UUID(str(plan["courier_id"]))
@@ -64,6 +85,12 @@ async def save_routes(
 
         if order_ids:
             await session.execute(update(Order).where(Order.id.in_(order_ids)).values(status_id=scheduled_id))
+
+        await _create_notifications(
+            session,
+            [*manager_ids, courier_id],
+            f"Создан маршрут {route.id}",
+        )
 
         created.append(route)
 


### PR DESCRIPTION
## Summary
- generate notifications for managers and couriers when saving routes
- expose an endpoint to mark notifications as read

## Testing
- `nox -s ruff_format`
- `nox -s ruff`
- `nox -s mypy` *(fails: Error importing plugin 'sqlalchemy.ext.mypy.plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68504585487c832ebe10eeb5e7eca85f