### PR TITLE
Add route sheet chart

### DIFF
--- a/app/orm-service/src/api/route_sheet_chart.py
+++ b/app/orm-service/src/api/route_sheet_chart.py
@@ -1,0 +1,18 @@
+# src/api/route_sheet_chart.py
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies.db import get_session_with_user
+from src.repositories.charts.route_sheet_chart import RouteSheetChartRepository
+from src.schemas.route_sheet_chart import RouteSheetChart, RouteSheetChartFilter
+
+router = APIRouter(prefix="/charts/route-sheet", tags=["Route Sheet Chart"])
+
+
+@router.get("/", response_model=list[RouteSheetChart])
+async def get_route_sheet_chart(
+    filters: RouteSheetChartFilter = Depends(),
+    session: AsyncSession = Depends(get_session_with_user),
+) -> list[RouteSheetChart]:
+    repo = RouteSheetChartRepository(session)
+    return await repo.get_chart(filters)

--- a/app/orm-service/src/main.py
+++ b/app/orm-service/src/main.py
@@ -15,6 +15,7 @@ from src.api import (
     logistics,
     order,
     order_chart,
+    route_sheet_chart,
     routing_chart,
     tracking_chart,
     user,
@@ -66,3 +67,4 @@ app.include_router(routing_chart.router)
 app.include_router(tracking_chart.router)
 app.include_router(equipment_chart.router)
 app.include_router(invoice_chart.router)
+app.include_router(route_sheet_chart.router)

--- a/app/orm-service/src/repositories/charts/route_sheet_chart.py
+++ b/app/orm-service/src/repositories/charts/route_sheet_chart.py
@@ -1,0 +1,70 @@
+# src/repositories/charts/route_sheet_chart.py
+from typing import Sequence, Tuple
+from uuid import UUID
+
+from sqlalchemy import Result, func, select
+from sqlalchemy.engine.row import Row
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Select
+
+from src.db.models import EventType, Order, Route, RouteItem, Tracking, User
+from src.schemas.route_sheet_chart import RouteSheetChart, RouteSheetChartFilter
+from src.utils.sqlalchemy_expr import full_name_expr
+
+
+class RouteSheetChartRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_chart(self, filters: RouteSheetChartFilter) -> list[RouteSheetChart]:
+        stmt: Select[Tuple[UUID, str, int, int]] = (
+            select(
+                Route.id,
+                full_name_expr().label("full_name"),
+                func.count(RouteItem.id).label("count_orders"),
+                func.count(
+                    func.distinct(
+                        func.case(
+                            (
+                                EventType.code.in_(["installed", "picked_up"]),
+                                Tracking.route_item_id,
+                            ),
+                            else_=None,
+                        )
+                    )
+                ).label("completed_orders"),
+            )
+            .join(User, User.id == Route.courier_id)
+            .join(RouteItem, RouteItem.route_id == Route.id)
+            .join(Order, Order.id == RouteItem.order_id)
+            .outerjoin(Tracking, Tracking.route_item_id == RouteItem.id)
+            .outerjoin(EventType, EventType.id == Tracking.event_type_id)
+            .group_by(Route.id, User.first_name, User.last_name)
+        )
+
+        if filters.search:
+            like = f"%{filters.search.lower()}%"
+            stmt = stmt.where(func.lower(full_name_expr()).like(like))
+
+        field_map = {
+            "id": Route.id,
+            "full_name": full_name_expr(),
+            "count_orders": func.count(RouteItem.id),
+        }
+        sort_col = field_map.get(filters.order_by, Route.id)
+        stmt = stmt.order_by(sort_col.desc() if filters.order_dir == "desc" else sort_col.asc())
+
+        stmt = stmt.limit(filters.limit).offset(filters.offset)
+
+        res: Result[Tuple[UUID, str, int, int]] = await self.session.execute(stmt)
+        rows: Sequence[Row[Tuple[UUID, str, int, int]]] = res.fetchall()
+
+        return [
+            RouteSheetChart(
+                id=r[0],
+                full_name=r[1],
+                count_orders=r[2],
+                status=round((r[3] or 0) / (r[2] or 1) * 100),
+            )
+            for r in rows
+        ]

--- a/app/orm-service/src/schemas/route_sheet_chart.py
+++ b/app/orm-service/src/schemas/route_sheet_chart.py
@@ -1,0 +1,23 @@
+# src/schemas/route_sheet_chart.py
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RouteSheetChart(BaseModel):
+    id: UUID
+    full_name: str
+    count_orders: int
+    status: int  # Процент выполнения (0–100)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RouteSheetChartFilter(BaseModel):
+    search: str | None = None
+    order_by: Literal["id", "full_name", "count_orders"] = "id"
+    order_dir: Literal["asc", "desc"] = "asc"
+
+    limit: int = Field(default=10, le=100)
+    offset: int = 0


### PR DESCRIPTION
## Summary
- add `RouteSheetChart` schema for displaying route sheets
- implement repository query for route sheet chart
- add API endpoint for route sheet chart
- register new route in the service app

## Testing
- `nox -s ruff_format`
- `nox -s ruff`
- `nox -s mypy` *(fails: "Class cannot subclass `BaseModel`" and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_685046c9f2ac832ebe98b623450d9745