### PR TITLE
Add notifications API

### DIFF
--- a/app/orm-service/src/api/notification.py
+++ b/app/orm-service/src/api/notification.py
@@ -1,0 +1,39 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies.auth import get_current_user
+from src.dependencies.db import get_session_with_user
+from src.repositories.notification import NotificationRepository
+from src.schemas.auth import CurrentUser
+from src.schemas.notification import NotificationCreate, NotificationRead
+
+router = APIRouter(prefix="/notifications", tags=["Notifications"])
+
+
+@router.get("/", response_model=list[NotificationRead])
+async def get_notifications(
+    session: AsyncSession = Depends(get_session_with_user),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> list[NotificationRead]:
+    notifications = await NotificationRepository().list_by_user(session, current_user.id)
+    return [NotificationRead.model_validate(n) for n in notifications]
+
+
+@router.patch("/{notification_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def mark_as_read(
+    notification_id: UUID,
+    session: AsyncSession = Depends(get_session_with_user),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> None:
+    await NotificationRepository().mark_as_read(session, notification_id, current_user.id)
+
+
+@router.post("/send", response_model=NotificationRead, status_code=status.HTTP_201_CREATED)
+async def send_notification(
+    data: NotificationCreate,
+    session: AsyncSession = Depends(get_session_with_user),
+) -> NotificationRead:
+    notification = await NotificationRepository().create_read(session, data)
+    return NotificationRead.model_validate(notification)

--- a/app/orm-service/src/main.py
+++ b/app/orm-service/src/main.py
@@ -13,6 +13,7 @@ from src.api import (
     equipment_chart,
     invoice_chart,
     logistics,
+    notification,
     order,
     order_chart,
     route_sheet_chart,
@@ -56,6 +57,8 @@ app.include_router(user.router)
 app.include_router(order.router)
 app.include_router(equipment.router)
 app.include_router(contract.router)
+# notifications
+app.include_router(notification.router)
 # widget
 app.include_router(widget.router)
 # dashboard

--- a/app/orm-service/src/repositories/notification.py
+++ b/app/orm-service/src/repositories/notification.py
@@ -1,0 +1,31 @@
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import Select, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.db.models import Notification
+from src.schemas.notification import NotificationCreate
+
+
+class NotificationRepository:
+    async def list_by_user(self, session: AsyncSession, user_id: UUID) -> Sequence[Notification]:
+        stmt: Select[tuple[Notification]] = (
+            select(Notification).where(Notification.user_id == user_id).order_by(Notification.created_at.desc())
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars())
+
+    async def mark_as_read(self, session: AsyncSession, notification_id: UUID, user_id: UUID) -> None:
+        await session.execute(
+            update(Notification)
+            .where(Notification.id == notification_id, Notification.user_id == user_id)
+            .values(is_read=True)
+        )
+
+    async def create_read(self, session: AsyncSession, data: NotificationCreate) -> Notification:
+        notification = Notification(user_id=data.user_id, text=data.text, is_read=True)
+        session.add(notification)
+        await session.flush()
+        await session.refresh(notification)
+        return notification

--- a/app/orm-service/src/schemas/notification.py
+++ b/app/orm-service/src/schemas/notification.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class NotificationCreate(BaseModel):
+    user_id: UUID
+    text: str
+
+
+class NotificationRead(BaseModel):
+    id: UUID
+    user_id: UUID
+    text: str
+    created_at: datetime
+    is_read: bool
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- implement Notification schemas
- add NotificationRepository with list, mark read and send functionality
- expose notification endpoints for fetching and marking as read, and sending a read notification
- register new router in FastAPI application

## Testing
- `nox -s ruff_format`
- `nox -s ruff`
- `nox -s mypy`


------
https://chatgpt.com/codex/tasks/task_e_685056c96a10832e8d7b2b7beb0c7995