### PR TITLE
Add route endpoints

### DIFF
--- a/app/orm-service/src/api/route.py
+++ b/app/orm-service/src/api/route.py
@@ -1,0 +1,28 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies.db import get_session_with_user
+from src.repositories.route import RouteRepository
+from src.schemas.route import RouteItemStatus, RouteRead
+
+router = APIRouter(prefix="/route", tags=["Route"])
+
+
+@router.get("/courier/{courier_id}", response_model=list[RouteRead])
+async def list_routes_for_courier(
+    courier_id: UUID,
+    session: AsyncSession = Depends(get_session_with_user),
+) -> list[RouteRead]:
+    repo = RouteRepository()
+    return await repo.list_by_courier(session, courier_id)
+
+
+@router.get("/{route_id}/items", response_model=list[RouteItemStatus])
+async def list_route_items_with_status(
+    route_id: UUID,
+    session: AsyncSession = Depends(get_session_with_user),
+) -> list[RouteItemStatus]:
+    repo = RouteRepository()
+    return await repo.list_items_with_status(session, route_id)

--- a/app/orm-service/src/main.py
+++ b/app/orm-service/src/main.py
@@ -16,6 +16,7 @@ from src.api import (
     notification,
     order,
     order_chart,
+    route,
     route_sheet_chart,
     routing_chart,
     tracking_chart,
@@ -52,6 +53,8 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 # logistics
 app.include_router(logistics.router)
+# routes
+app.include_router(route.router)
 # entities
 app.include_router(user.router)
 app.include_router(order.router)

--- a/app/orm-service/src/repositories/route.py
+++ b/app/orm-service/src/repositories/route.py
@@ -1,0 +1,49 @@
+from typing import Sequence, Tuple
+from uuid import UUID
+
+from sqlalchemy import Result, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Select
+
+from src.db.models import EventType, Route, RouteItem, Tracking
+from src.schemas.route import RouteItemStatus, RouteRead
+
+
+class RouteRepository:
+    async def list_by_courier(self, session: AsyncSession, courier_id: UUID) -> list[RouteRead]:
+        stmt: Select[Tuple[Route]] = select(Route).where(Route.courier_id == courier_id).order_by(Route.date.desc())
+        res: Result[Tuple[Route]] = await session.execute(stmt)
+        routes: Sequence[Route] = res.scalars().all()
+        return [RouteRead.model_validate(r) for r in routes]
+
+    async def list_items_with_status(self, session: AsyncSession, route_id: UUID) -> list[RouteItemStatus]:
+        last_evt = (
+            select(
+                Tracking.route_item_id,
+                func.max(Tracking.event_time).label("last_time"),
+            )
+            .group_by(Tracking.route_item_id)
+            .subquery()
+        )
+
+        stmt: Select[Tuple[UUID, UUID | None, int, str | None]] = (
+            select(
+                RouteItem.id,
+                RouteItem.order_id,
+                RouteItem.sequence,
+                EventType.description,
+            )
+            .select_from(RouteItem)
+            .where(RouteItem.route_id == route_id)
+            .outerjoin(last_evt, last_evt.c.route_item_id == RouteItem.id)
+            .outerjoin(
+                Tracking,
+                (Tracking.route_item_id == RouteItem.id) & (Tracking.event_time == last_evt.c.last_time),
+            )
+            .outerjoin(EventType, EventType.id == Tracking.event_type_id)
+            .order_by(RouteItem.sequence)
+        )
+
+        res: Result[Tuple[UUID, UUID | None, int, str | None]] = await session.execute(stmt)
+        rows: Sequence[Tuple[UUID, UUID | None, int, str | None]] = res.fetchall()
+        return [RouteItemStatus(id=r[0], order_id=r[1], sequence=r[2], status=r[3]) for r in rows]

--- a/app/orm-service/src/schemas/route.py
+++ b/app/orm-service/src/schemas/route.py
@@ -1,0 +1,21 @@
+from datetime import date, datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class RouteRead(BaseModel):
+    id: UUID
+    courier_id: UUID
+    date: date
+    planned_start: datetime
+    planned_end: datetime
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RouteItemStatus(BaseModel):
+    id: UUID
+    order_id: UUID | None
+    sequence: int
+    status: str | None = None
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- add new schema for routes
- implement `RouteRepository` with helper methods
- create `/route` API with endpoints to list courier routes and route items
- register router in main app

## Testing
- `nox -s ruff`
- `nox -s ruff_format`
- `nox -s mypy` *(fails: Error importing plugin "sqlalchemy.ext.mypy.plugin")*

------
https://chatgpt.com/codex/tasks/task_e_685067b12b7c832ea42408992e9f26ff