### PR TITLE
Implement unread notification API

### DIFF
--- a/app/orm-service/src/api/notification.py
+++ b/app/orm-service/src/api/notification.py
@@ -14,6 +14,26 @@ from src.schemas.notification import NotificationCreate, NotificationRead
 router = APIRouter(prefix="/notifications", tags=["Notifications"])
 
 
+@router.get("/unread", response_model=list[NotificationRead])
+async def get_unread_notifications(
+    session: AsyncSession = Depends(get_session_with_user),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> list[NotificationRead]:
+    repo = NotificationRepository()
+    notifications: Sequence[Notification] = await repo.list_unread_by_user(session, current_user.id)
+    if notifications:
+        await repo.mark_all_as_read(session, current_user.id)
+    return [NotificationRead.model_validate(n) for n in notifications]
+
+
+@router.get("/unread_count", response_model=int)
+async def unread_count(
+    session: AsyncSession = Depends(get_session_with_user),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> int:
+    return await NotificationRepository().count_unread_by_user(session, current_user.id)
+
+
 @router.get("/", response_model=list[NotificationRead])
 async def get_notifications(
     session: AsyncSession = Depends(get_session_with_user),

--- a/app/orm-service/src/repositories/notification.py
+++ b/app/orm-service/src/repositories/notification.py
@@ -1,7 +1,7 @@
 from typing import Sequence
 from uuid import UUID
 
-from sqlalchemy import Select, select, update
+from sqlalchemy import Select, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.db.models import Notification
@@ -15,6 +15,31 @@ class NotificationRepository:
         )
         result = await session.execute(stmt)
         return list(result.scalars())
+
+    async def list_unread_by_user(self, session: AsyncSession, user_id: UUID) -> Sequence[Notification]:
+        stmt: Select[tuple[Notification]] = (
+            select(Notification)
+            .where(Notification.user_id == user_id, Notification.is_read.is_(False))
+            .order_by(Notification.created_at.desc())
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars())
+
+    async def mark_all_as_read(self, session: AsyncSession, user_id: UUID) -> None:
+        await session.execute(
+            update(Notification)
+            .where(Notification.user_id == user_id, Notification.is_read.is_(False))
+            .values(is_read=True)
+        )
+
+    async def count_unread_by_user(self, session: AsyncSession, user_id: UUID) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(Notification)
+            .where(Notification.user_id == user_id, Notification.is_read.is_(False))
+        )
+        result = await session.execute(stmt)
+        return int(result.scalar_one())
 
     async def mark_as_read(self, session: AsyncSession, notification_id: UUID, user_id: UUID) -> None:
         await session.execute(


### PR DESCRIPTION
## Summary
- add unread notification repository methods
- expose `/notifications/unread` and `/notifications/unread_count` endpoints

## Testing
- `python -m py_compile app/orm-service/src/repositories/notification.py app/orm-service/src/api/notification.py`


------
https://chatgpt.com/codex/tasks/task_e_685070a0591c832e93a6ac167720cc63