### PR TITLE
Add tracking event API

### DIFF
--- a/app/orm-service/src/api/tracking.py
+++ b/app/orm-service/src/api/tracking.py
@@ -1,0 +1,27 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies.db import get_session_with_user
+from src.repositories.tables.tracking import TrackingRepository
+from src.schemas.tracking import OrderLastEvent, TrackingCreate, TrackingRead
+
+router = APIRouter(prefix="/tracking", tags=["Tracking"])
+
+
+@router.post("/", response_model=TrackingRead, status_code=201)
+async def create_tracking(
+    data: TrackingCreate,
+    session: AsyncSession = Depends(get_session_with_user),
+) -> TrackingRead:
+    return await TrackingRepository().create(session, data)
+
+
+@router.get("/order/{order_id}", response_model=OrderLastEvent)
+async def get_last_event(
+    order_id: UUID,
+    session: AsyncSession = Depends(get_session_with_user),
+) -> OrderLastEvent:
+    description: str | None = await TrackingRepository().get_last_event_description(session, order_id)
+    return OrderLastEvent(order_id=order_id, description=description)

--- a/app/orm-service/src/main.py
+++ b/app/orm-service/src/main.py
@@ -19,6 +19,7 @@ from src.api import (
     route,
     route_sheet_chart,
     routing_chart,
+    tracking,
     tracking_chart,
     user,
     user_chart,
@@ -70,6 +71,7 @@ app.include_router(dashboard.router)
 app.include_router(user_chart.router)
 app.include_router(order_chart.router)
 app.include_router(routing_chart.router)
+app.include_router(tracking.router)
 app.include_router(tracking_chart.router)
 app.include_router(equipment_chart.router)
 app.include_router(route_sheet_chart.router)

--- a/app/orm-service/src/repositories/tables/tracking.py
+++ b/app/orm-service/src/repositories/tables/tracking.py
@@ -1,0 +1,28 @@
+from uuid import UUID
+
+from sqlalchemy import Result, Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.db.models import EventType, RouteItem, Tracking
+from src.repositories.tables.base import CRUDRepository
+from src.schemas.tracking import TrackingCreate, TrackingUpdate
+
+
+class TrackingRepository(CRUDRepository[Tracking, TrackingCreate, TrackingUpdate]):
+    def __init__(self) -> None:
+        super().__init__(Tracking)
+
+    async def get_last_event_description(
+        self, session: AsyncSession, order_id: UUID
+    ) -> str | None:
+        stmt: Select[tuple[str]] = (
+            select(EventType.description)
+            .select_from(Tracking)
+            .join(RouteItem, RouteItem.id == Tracking.route_item_id)
+            .join(EventType, EventType.id == Tracking.event_type_id)
+            .where(RouteItem.order_id == order_id)
+            .order_by(Tracking.event_time.desc())
+            .limit(1)
+        )
+        res: Result[tuple[str]] = await session.execute(stmt)
+        return res.scalars().first()

--- a/app/orm-service/src/schemas/tracking.py
+++ b/app/orm-service/src/schemas/tracking.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class _TrackingBase(BaseModel):
+    route_item_id: UUID
+    event_type_id: int
+    event_time: datetime
+
+
+class TrackingCreate(_TrackingBase):
+    pass
+
+
+class TrackingUpdate(BaseModel):
+    pass
+
+
+class TrackingRead(_TrackingBase):
+    id: UUID
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OrderLastEvent(BaseModel):
+    order_id: UUID
+    description: str | None
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- add schemas for tracking events
- create repository for tracking table
- implement tracking API for creating events and fetching the latest event by order
- wire new tracking router into orm-service

## Testing
- `ruff check app/orm-service/src/api/tracking.py app/orm-service/src/repositories/tables/tracking.py app/orm-service/src/schemas/tracking.py app/orm-service/src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685080f72e38832ebe2edafc3b7b166e