### PR TITLE
Fix tracking repo

### DIFF
--- a/app/orm-service/src/api/tracking.py
+++ b/app/orm-service/src/api/tracking.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.db.models import Tracking
 from src.dependencies.db import get_session_with_user
 from src.repositories.tables.tracking import TrackingRepository
-from src.schemas.tracking import OrderLastEvent, TrackingCreate, TrackingRead
+from src.schemas.tracking import RouteLastEvent, TrackingCreate, TrackingRead
 
 router = APIRouter(prefix="/tracking", tags=["Tracking"])
 
@@ -17,13 +17,13 @@ async def create_tracking(
     session: AsyncSession = Depends(get_session_with_user),
 ) -> TrackingRead:
     tracking: Tracking = await TrackingRepository().create(session, data)
-    return TTrackingRead.model_validate(tracking)
+    return TrackingRead.model_validate(tracking)
 
 
-@router.get("/order/{order_id}", response_model=OrderLastEvent)
+@router.get("/route/{route_id}", response_model=RouteLastEvent)
 async def get_last_event(
-    order_id: UUID,
+    route_id: UUID,
     session: AsyncSession = Depends(get_session_with_user),
-) -> OrderLastEvent:
-    description: str | None = await TrackingRepository().get_last_event_description(session, order_id)
-    return OrderLastEvent(order_id=order_id, description=description)
+) -> RouteLastEvent:
+    description: str | None = await TrackingRepository().get_last_event_description(session, route_id)
+    return RouteLastEvent(route_id=route_id, description=description)

--- a/app/orm-service/src/repositories/tables/tracking.py
+++ b/app/orm-service/src/repositories/tables/tracking.py
@@ -1,6 +1,11 @@
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Tuple
+from uuid import UUID
 
-from src.db.models import Tracking
+from sqlalchemy import Result, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Select
+
+from src.db.models import EventType, RouteItem, Tracking
 from src.repositories.tables.base import CRUDRepository
 from src.schemas.tracking import TrackingCreate, TrackingUpdate
 
@@ -11,6 +16,19 @@ class TrackingRepository(CRUDRepository[Tracking, TrackingCreate, TrackingUpdate
 
     async def create_raw(self, session: AsyncSession, obj_in: TrackingCreate) -> Tracking:
         return await super().create(session, obj_in)
+
+    async def get_last_event_description(self, session: AsyncSession, route_id: UUID) -> str | None:
+        stmt: Select[Tuple[str]] = (
+            select(EventType.description)
+            .select_from(Tracking)
+            .join(RouteItem, RouteItem.id == Tracking.route_item_id)
+            .join(EventType, EventType.id == Tracking.event_type_id)
+            .where(RouteItem.route_id == route_id)
+            .order_by(Tracking.event_time.desc())
+            .limit(1)
+        )
+        res: Result[Tuple[str]] = await session.execute(stmt)
+        return res.scalars().first()
 
     # async def get_last_event_description(self, session: AsyncSession, order_id: UUID) -> str | None:
     #     stmt: Select[tuple[str]] = (

--- a/app/orm-service/src/schemas/tracking.py
+++ b/app/orm-service/src/schemas/tracking.py
@@ -25,3 +25,9 @@ class OrderLastEvent(BaseModel):
     order_id: UUID
     description: str | None
     model_config = ConfigDict(from_attributes=True)
+
+
+class RouteLastEvent(BaseModel):
+    route_id: UUID
+    description: str | None
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- fix tracking API to use route IDs
- provide `RouteLastEvent` schema
- implement missing last event lookup

## Testing
- `nox -s ruff_format`
- `nox -s ruff`
- `nox -s mypy` *(fails: Error importing plugin "sqlalchemy.ext.mypy.plugin")*

------
https://chatgpt.com/codex/tasks/task_e_68509b2ac438832e8c8c788a5dd345e9