### PR TITLE
Implement RouteItem management API

### DIFF
--- a/app/orm-service/src/api/route.py
+++ b/app/orm-service/src/api/route.py
@@ -1,11 +1,13 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.dependencies.db import get_session_with_user
 from src.repositories.route import RouteRepository
+from src.repositories.tables.route_item import RouteItemRepository
 from src.schemas.route import RouteItemStatus, RouteRead
+from src.schemas.route_item import RouteItemCreate, RouteItemRead
 
 router = APIRouter(prefix="/route", tags=["Route"])
 
@@ -25,3 +27,21 @@ async def list_route_items_with_status(
 ) -> list[RouteItemStatus]:
     repo = RouteRepository()
     return await repo.list_items_with_status(session, route_id)
+
+
+@router.post("/item", status_code=status.HTTP_201_CREATED, response_model=RouteItemRead)
+async def add_route_item(
+    payload: RouteItemCreate,
+    session: AsyncSession = Depends(get_session_with_user),
+) -> RouteItemRead:
+    item = await RouteItemRepository().add_item(session, payload.route_id, payload.order_id)
+    return RouteItemRead.model_validate(item)
+
+
+@router.delete("/item/{order_id}")
+async def delete_route_item(
+    order_id: UUID,
+    session: AsyncSession = Depends(get_session_with_user),
+) -> dict[str, str]:
+    await RouteItemRepository().delete_by_order(session, order_id)
+    return {"detail": "Маршрут обновлён"}

--- a/app/orm-service/src/repositories/tables/route_item.py
+++ b/app/orm-service/src/repositories/tables/route_item.py
@@ -1,0 +1,32 @@
+from typing import Tuple
+from uuid import UUID
+
+from sqlalchemy import Select, delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.db.models import RouteItem
+from src.repositories.tables.base import CRUDRepository
+from src.schemas.route_item import RouteItemCreate, RouteItemUpdate
+from src.utils.http_error import NotFoundError
+
+
+class RouteItemRepository(CRUDRepository[RouteItem, RouteItemCreate, RouteItemUpdate]):
+    def __init__(self) -> None:
+        super().__init__(RouteItem)
+
+    async def add_item(self, session: AsyncSession, route_id: UUID, order_id: UUID) -> RouteItem:
+        stmt: Select[Tuple[int]] = select(func.max(RouteItem.sequence)).where(RouteItem.route_id == route_id)
+        last_seq: int | None = await session.scalar(stmt)
+        item = RouteItem(route_id=route_id, order_id=order_id, sequence=(last_seq or 0) + 1)
+        session.add(item)
+        await session.flush()
+        await session.refresh(item)
+        return item
+
+    async def delete_by_order(self, session: AsyncSession, order_id: UUID) -> None:
+        exists_stmt: Select[Tuple[UUID]] = select(RouteItem.id).where(RouteItem.order_id == order_id)
+        exists: UUID | None = await session.scalar(exists_stmt)
+        if exists is None:
+            raise NotFoundError("Маршрутный пункт не найден")
+
+        await session.execute(delete(RouteItem).where(RouteItem.order_id == order_id))

--- a/app/orm-service/src/schemas/route_item.py
+++ b/app/orm-service/src/schemas/route_item.py
@@ -1,0 +1,21 @@
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class RouteItemCreate(BaseModel):
+    route_id: UUID
+    order_id: UUID
+
+
+class RouteItemUpdate(BaseModel):
+    pass
+
+
+class RouteItemRead(BaseModel):
+    id: UUID
+    route_id: UUID
+    order_id: UUID
+    sequence: int
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- create schema for RouteItem
- add repository for RouteItem CRUD logic
- extend route API with endpoints to add/delete RouteItem

## Testing
- `ruff format app/orm-service/src/schemas/route_item.py app/orm-service/src/repositories/tables/route_item.py app/orm-service/src/api/route.py`
- `ruff check app/orm-service/src/api/route.py app/orm-service/src/repositories/tables/route_item.py app/orm-service/src/schemas/route_item.py`

------
https://chatgpt.com/codex/tasks/task_e_6850a352177c832e96bc54e8dac35837