### PR TITLE
Implement order status updates during logistics processing

### DIFF
--- a/app/orm-service/src/api/logistics.py
+++ b/app/orm-service/src/api/logistics.py
@@ -5,10 +5,13 @@ from uuid import UUID
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.config import Settings, get_settings
+from src.db.models import Order
 from src.dependencies.db import get_session_with_user
+from src.repositories.tables.order_status import OrderStatusRepository
 from src.schemas.logistics import Logistics
 from src.services.logistics_service import build_logistics
 
@@ -16,6 +19,17 @@ router = APIRouter(prefix="/logistics", tags=["Logistics"])
 
 settings: Settings = get_settings()
 OSRM_URL: str = settings.osrm_service_url.rstrip("/")
+
+
+async def _update_orders_status(
+    session: AsyncSession,
+    order_ids: list[UUID],
+    code: str,
+) -> None:
+    if not order_ids:
+        return
+    status_id: int = await OrderStatusRepository().get_code_id(session, code)
+    await session.execute(update(Order).where(Order.id.in_(order_ids)).values(status_id=status_id))
 
 
 @router.post("/", status_code=status.HTTP_202_ACCEPTED)
@@ -26,6 +40,7 @@ async def get_logistics(
     logger.info(
         f"Building logistics for {len(order_ids)} orders",
     )
+    await _update_orders_status(session, order_ids, "in_processing")
     logistics: Logistics = await build_logistics(session, order_ids)
     try:
         async with httpx.AsyncClient(base_url=OSRM_URL, timeout=5.0) as client:
@@ -36,10 +51,12 @@ async def get_logistics(
     except httpx.RequestError as exc:
         detail: str = f"Failed to reach OSRM service at {OSRM_URL}: {exc}"
         logger.error(detail)
+        await _update_orders_status(session, order_ids, "new")
         raise HTTPException(status_code=502, detail=detail) from exc
 
-    if resp.status_code != status.HTTP_200_OK:
+    if resp.status_code not in (status.HTTP_200_OK, status.HTTP_202_ACCEPTED):
         logger.error(f"OSRM service returned {resp.status_code}: {resp.text}")
+        await _update_orders_status(session, order_ids, "new")
         raise HTTPException(status_code=resp.status_code, detail=resp.text)
 
     logger.info("Received routes from OSRM service")

--- a/app/osrm-service/src/api/logistics.py
+++ b/app/osrm-service/src/api/logistics.py
@@ -14,7 +14,7 @@ from src.db.session import AsyncSessionFactory
 from src.schemas.logistics import Logistics
 from src.services.logistics_builder import build_logistics
 from src.services.logistics_service import process_logistics
-from src.services.route_service import save_routes
+from src.services.route_service import save_routes, update_orders_status
 
 router = APIRouter(prefix="/logistics", tags=["Logistics"])
 
@@ -26,16 +26,36 @@ async def _save_routes_bg(plans: list[dict[str, Any]]) -> None:
 
 
 async def _process_and_save(payload: Logistics, settings: Settings) -> None:
-    routes: list[dict[str, Any]] = await process_logistics(payload, settings)
-    await _save_routes_bg(routes)
+    order_ids: list[UUID] = [o.order_id for o in payload.orders]
+    async with AsyncSessionFactory() as session:
+        async with session.begin():
+            await update_orders_status(session, order_ids, "in_processing")
+    try:
+        routes: list[dict[str, Any]] = await process_logistics(payload, settings)
+        await _save_routes_bg(routes)
+    except Exception:
+        async with AsyncSessionFactory() as session:
+            async with session.begin():
+                await update_orders_status(session, order_ids, "new")
+        raise
 
 
 async def _assign_routes_bg(order_ids: list[UUID], settings: Settings) -> None:
     async with AsyncSessionFactory() as session:
         async with session.begin():
-            payload: Logistics = await build_logistics(session, order_ids)
-            plans: list[dict[str, Any]] = await process_logistics(payload, settings)
-            await save_routes(session, plans)
+            await update_orders_status(session, order_ids, "in_processing")
+
+    try:
+        async with AsyncSessionFactory() as session:
+            async with session.begin():
+                payload: Logistics = await build_logistics(session, order_ids)
+                plans: list[dict[str, Any]] = await process_logistics(payload, settings)
+                await save_routes(session, plans)
+    except Exception:
+        async with AsyncSessionFactory() as session:
+            async with session.begin():
+                await update_orders_status(session, order_ids, "new")
+        raise
 
 
 @asynccontextmanager

--- a/app/osrm-service/src/services/route_service.py
+++ b/app/osrm-service/src/services/route_service.py
@@ -40,6 +40,20 @@ async def _create_notifications(session: AsyncSession, user_ids: Sequence[UUID],
     await session.flush()
 
 
+async def update_orders_status(
+    session: AsyncSession,
+    order_ids: Sequence[UUID],
+    code: str,
+) -> None:
+    """Bulk update status for orders by code."""
+    if not order_ids:
+        return
+    status_id: int = await _get_status_id(session, code)
+    await session.execute(
+        update(Order).where(Order.id.in_(order_ids)).values(status_id=status_id)
+    )
+
+
 async def save_routes(
     session: AsyncSession,
     plans: Sequence[dict[str, object]],


### PR DESCRIPTION
## Summary
- update order status when starting route planning
- rollback status if planning fails
- send pending status when calling OSRM service

## Testing
- `nox -s ruff` *(osrm-service)*
- `nox -s mypy` *(osrm-service) [fails]*
- `nox -s ruff_format && nox -s ruff` *(orm-service)*
- `nox -s mypy` *(orm-service) [fails]*

------
https://chatgpt.com/codex/tasks/task_e_6850d4b136dc832eaeebda459689a166