### PR TITLE
Fix equipment status updates

### DIFF
--- a/app/orm-service/src/repositories/tables/equipment.py
+++ b/app/orm-service/src/repositories/tables/equipment.py
@@ -49,6 +49,7 @@ class EquipmentRepository(CRUDRepository[Equipment, EquipmentCreate, EquipmentUp
         new_status_code: str,
         limit: int,
         model: str,
+        new_address_id: UUID | None = None,
     ) -> list[Equipment]:
         status_repo = EquipmentStatusRepository()
         old_status_id: int = await status_repo.get_code_id(session, old_status_code)
@@ -68,11 +69,32 @@ class EquipmentRepository(CRUDRepository[Equipment, EquipmentCreate, EquipmentUp
 
         for eq in equipment_list:
             eq.equipment_status_id = new_status_id
+            if new_address_id is not None:
+                eq.current_address_id = new_address_id
 
         await session.flush()
         return list(equipment_list)
 
-    async def update_status(self, session: AsyncSession, id: UUID | int, status: str) -> Equipment:
+    async def update_status(
+        self,
+        session: AsyncSession,
+        id: UUID | int,
+        status: str,
+        *,
+        address_id: UUID | None = None,
+    ) -> Equipment:
         equipment_status_id: int = await EquipmentStatusRepository().get_code_id(session, status)
-        obj_in = EquipmentUpdate(equipment_status_id=equipment_status_id)
+
+        if address_id is None and status == "available":
+            stmt = (
+                select(Warehouse.address_id)
+                .join(Equipment, Equipment.warehouse_id == Warehouse.id)
+                .where(Equipment.id == id)
+            )
+            address_id = await session.scalar(stmt)
+
+        obj_in = EquipmentUpdate(
+            equipment_status_id=equipment_status_id,
+            current_address_id=address_id,
+        )
         return await super().update_by_id(session, id, obj_in)

--- a/app/orm-service/src/repositories/tables/order.py
+++ b/app/orm-service/src/repositories/tables/order.py
@@ -29,6 +29,7 @@ from src.db.models import (
     Route,
     RouteItem,
     User,
+    Warehouse,
 )
 from src.repositories.tables.base import CRUDRepository
 from src.repositories.tables.client import ClientRepository
@@ -81,6 +82,7 @@ class OrderRepository(CRUDRepository[Order, OrderCreate, OrderUpdate]):
                 new_status_code="rented",
                 limit=eq.quantity,
                 model=heater_type.model,
+                new_address_id=client.address_id,
             )
 
             await OrderItemRepository().create(
@@ -124,6 +126,11 @@ class OrderRepository(CRUDRepository[Order, OrderCreate, OrderUpdate]):
         order.status_id = new_status_id
         await session.flush()
         await session.refresh(order)
+
+        if new_status_code in ("completed", "cancelled"):
+            equipment_list: list[Equipment] = await OrderItemRepository().get_item_from_order_id(session, order.id)
+            for equipment in equipment_list:
+                await EquipmentRepository().update_status(session, equipment.id, "available")
 
         await OrderHistoryRepository().create(
             session,
@@ -366,6 +373,14 @@ class OrderRepository(CRUDRepository[Order, OrderCreate, OrderUpdate]):
     async def delete(self, session: AsyncSession, id: UUID | int) -> None:
         equipment_list: list[Equipment] = await OrderItemRepository().get_item_from_order_id(session, id)
         for equipment in equipment_list:
-            await EquipmentRepository().update_status(session, equipment.id, "available")
+            warehouse_address_id: UUID | None = await session.scalar(
+                select(Warehouse.address_id).where(Warehouse.id == equipment.warehouse_id)
+            )
+            await EquipmentRepository().update_status(
+                session,
+                equipment.id,
+                "available",
+                address_id=warehouse_address_id,
+            )
 
         return await super().delete(session, id)


### PR DESCRIPTION
## Summary
- adjust equipment repositories to update address when status changes
- ensure orders set equipment address to client location when created
- update equipment location when orders complete or are deleted

## Testing
- `nox -s ruff_format`
- `nox -s ruff`
- `nox -s mypy` *(fails: untyped decorator errors)*

------
https://chatgpt.com/codex/tasks/task_e_68511add2e74832e9d4202c03d60c82c