### PR TITLE
Implement order status update on tracking events

### DIFF
--- a/app/orm-service/src/repositories/tables/tracking.py
+++ b/app/orm-service/src/repositories/tables/tracking.py
@@ -9,6 +9,7 @@ from sqlalchemy.sql import Select
 from src.db.models import EventType, RouteItem, Tracking
 from src.repositories.tables.base import CRUDRepository
 from src.repositories.tables.event_type import EventTypeRepository
+from src.repositories.tables.order import OrderRepository
 from src.schemas.tracking import TrackingCreate, TrackingCreateAPI, TrackingUpdate
 
 
@@ -23,7 +24,21 @@ class TrackingRepository(CRUDRepository[Tracking, TrackingCreate, TrackingUpdate
             event_type_id=event_type_id,
             event_time=datetime.now(tz=timezone.utc),
         )
-        return await super().create(session, obj_in)
+        tracking: Tracking = await super().create(session, obj_in)
+
+        status_map: dict[str, str] = {
+            "Выезд": "on_delivery",
+            "Прибытие": "on_delivery",
+            "Монтаж завершён": "in_rent",
+            "Демонтаж завершён": "completed",
+        }
+        new_status: str | None = status_map.get(raw_data.event_type)
+        if new_status:
+            route_item: RouteItem | None = await session.get(RouteItem, raw_data.route_item_id)
+            if route_item and route_item.order_id:
+                await OrderRepository().update_status(session, route_item.order_id, new_status)
+
+        return tracking
 
     async def get_last_event_description(self, session: AsyncSession, route_id: UUID) -> str | None:
         stmt: Select[Tuple[str]] = (


### PR DESCRIPTION
## Summary
- trigger order status updates when new tracking events are created

## Testing
- `nox -s ruff_format`
- `nox -s ruff`
- `nox -s mypy` *(fails: Error importing plugin 'sqlalchemy.ext.mypy.plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68511d26e164832eb10c7fbeeec29c40